### PR TITLE
feat: add baseline GRPO experiment for countdown task

### DIFF
--- a/experiments/countdown_baseline.py
+++ b/experiments/countdown_baseline.py
@@ -132,8 +132,19 @@ def print_summary(output_dir: Path) -> None:
     print("=" * 50)
 
 
+_RUNNER_INTERNAL_MAX_EPISODES = 10  # Hardcoded in RolloutRunner.__init__
+
+
 def run_baseline(config: BaselineConfig) -> None:
     """Run the baseline GRPO experiment on countdown."""
+    if config.episodes_per_step > _RUNNER_INTERNAL_MAX_EPISODES:
+        raise ValueError(
+            f"episodes_per_step ({config.episodes_per_step}) exceeds "
+            f"RolloutRunner's internal buffer capacity "
+            f"({_RUNNER_INTERNAL_MAX_EPISODES}). Episodes would be "
+            f"silently evicted before reaching the training buffer."
+        )
+
     output_dir = Path(config.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_countdown_baseline.py
+++ b/tests/test_countdown_baseline.py
@@ -85,6 +85,22 @@ class TestBaselineConfig:
         config = BaselineConfig()
         assert not hasattr(config, "num_generations_per_prompt")
 
+    def test_episodes_per_step_within_runner_limit(self):
+        from experiments.countdown_baseline import (
+            BaselineConfig,
+            _RUNNER_INTERNAL_MAX_EPISODES,
+        )
+
+        config = BaselineConfig()
+        assert config.episodes_per_step <= _RUNNER_INTERNAL_MAX_EPISODES
+
+    def test_rejects_episodes_per_step_exceeding_runner_limit(self):
+        from experiments.countdown_baseline import BaselineConfig, run_baseline
+
+        config = BaselineConfig(episodes_per_step=15)
+        with pytest.raises(ValueError, match="silently evicted"):
+            run_baseline(config)
+
 
 # ---------------------------------------------------------------------------
 # Helper function tests


### PR DESCRIPTION
## Summary
- Add `experiments/countdown_baseline.py`: self-contained script that wires LoRA, GRPO training, countdown rewards, and EmergenceLogger into a reproducible baseline run
- Add `tests/test_countdown_baseline.py`: 20 mocked unit tests (no GPU required) covering config, helpers, reward integration, environment setup, and a full smoke test
- No changes to existing modules — pure integration of existing components

## Test plan
- [x] `uv run pytest tests/test_countdown_baseline.py -v` — 20/20 pass
- [x] `uv run pytest -x -q` — 250/250 pass, no regressions
- [ ] Manual: `uv run python experiments/countdown_baseline.py --steps 10 --output results/test_run` (requires model download)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a self-contained GRPO baseline experiment script for the Countdown task with LoRA fine-tuning, structured logging, and reproducible configuration, backed by comprehensive mocked tests.

New Features:
- Add an experiments/countdown_baseline.py script that runs a configurable GRPO training loop on the Countdown task with LoRA adapters and structured emergence logging.
- Expose a BaselineConfig dataclass and CLI to control model, training, generation, dataset, and output parameters for the baseline run.

Tests:
- Add tests/test_countdown_baseline.py with mocked unit tests covering config defaults/serialization, helper utilities, environment and reward integration, emergence logging, and a full run_baseline smoke test.