### PR TITLE
feat: rollout throughput optimizations (Opts 1-4) #47

### DIFF
--- a/experiments/countdown_reasoning_lora.py
+++ b/experiments/countdown_reasoning_lora.py
@@ -249,6 +249,7 @@ def run_experiment(config: ReasoningConfig) -> None:
             max_tokens=config.max_completion_tokens,
             tokenizer=tokenizer,
             examples=problems,
+            group_size=config.episodes_per_step,
         )
 
     policy_fn = create_policy(


### PR DESCRIPTION
## Summary

Implements the 4-optimization plan from #47 to reduce rollout collection time — the dominant bottleneck at 83.5% of step time (17.5s/21s per step).

- **Opt 1 — Same-prompt groups**: `group_size` parameter on `TextGenerationEnv` so GRPO compares completions of the same prompt (fixes semantic bug where advantages were normalized across different problems)
- **Opt 2 — Shared KV-cache prefill**: When all prompts are identical (GRPO groups), prefill once with B=1 and clone the cache via mlx_lm `.merge()` protocol — avoids B redundant prefill passes
- **Opt 3 — Per-sequence logprob accumulation**: Replaces the deferred `[steps, B]` tensor approach to be compatible with variable batch sizes from compaction
- **Opt 4 — Early-exit batch compaction**: When sequences hit EOS, removes them from the active batch via mlx_lm `cache.filter()` API, reducing GPU compute for subsequent decode steps

### Files changed
| File | Change |
|------|--------|
| `textpolicy/environment/text_generation.py` | `group_size` param in `__init__`, `reset()`, `step()`, `clone()` |
| `textpolicy/generation/mlx_generation.py` | Shared prefill, `_clone_single_cache_to_batch`, decode loop with compaction |
| `experiments/countdown_reasoning_lora.py` | Wires `group_size=episodes_per_step` |
| `tests/test_batched_generation.py` | 15 new tests (group cycling, shared prefill, batch compaction) |

### Profiling results (real model, Trinity-Nano-Preview 4-bit)
Decode loop decomposition on B=8, max_tokens=256:
```
eval_sync     11.79s  (91.3%)  46.22 ms/step  ← irreducible GPU compute
tolist_sync    0.55s  ( 4.3%)   2.17 ms/step
model_forward  0.53s  ( 4.1%)   2.06 ms/step
everything else < 0.3%
```

Shared prefill: ~6x prefill speedup (synthetic), 1.30x on real model.  
Batch compaction: saves GPU compute proportional to finished sequences (biggest wins on tasks with variable completion lengths).

## Test plan

- [x] All 609 tests pass (`uv run pytest`)
- [x] Real-model perf tests pass (`uv run pytest -m requires_model`)
- [x] Shared prefill correctness: greedy decode parity verified on real Arcee model (B=4 identical prompts produce identical output matching solo generation)
- [x] Cache cloning uses mlx_lm `.merge()` protocol (not raw `mx.repeat` which corrupts `RotatingKVCache`)
- [ ] Run `uv run python experiments/countdown_reasoning_lora.py --steps 3 --profile-training` and post before/after timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/teilomillet/textpolicy/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
