### PR TITLE
feat: paper-faithful GTPO (arXiv 2508.04349)

### DIFF
--- a/tests/test_gtpo_faithful.py
+++ b/tests/test_gtpo_faithful.py
@@ -519,6 +519,19 @@ class TestEdgeCases:
         with pytest.raises(ValueError, match="rewards length"):
             compute_gtpo_shaped_rewards(rewards, entropies, episode_lengths)
 
+    def test_new_logprobs_shape_mismatch_raises(self):
+        """Scalar/short new_logprobs silently broadcasts in MLX — must fail fast."""
+        old_lp = mx.array([-1.0, -1.0, -1.0, -1.0])
+        new_lp_scalar = mx.array([-1.0])  # length 1 != 4
+        rewards = [1.0, 0.0]
+        episode_lengths = [2, 2]
+        entropies = mx.array([2.0, 3.0, 1.0, 4.0])
+
+        with pytest.raises(ValueError, match="new_logprobs shape"):
+            gtpo_loss_faithful(
+                old_lp, new_lp_scalar, rewards, entropies, episode_lengths
+            )
+
 
 # ---------------------------------------------------------------------------
 # H8: Gradient detachment (Remark 2.5)

--- a/textpolicy/algorithms/grpo.py
+++ b/textpolicy/algorithms/grpo.py
@@ -884,6 +884,13 @@ def gtpo_loss_faithful(
     References:
         Eq. 3, 5, 6, 7 — arXiv 2508.04349
     """
+    if new_logprobs.shape != old_logprobs.shape:
+        raise ValueError(
+            f"new_logprobs shape {new_logprobs.shape} != "
+            f"old_logprobs shape {old_logprobs.shape}. "
+            f"Both must be flat 1D with the same number of tokens."
+        )
+
     total_tokens = old_logprobs.shape[0]
     if total_tokens == 0:
         return mx.array(0.0)


### PR DESCRIPTION
## Summary

- Add paper-exact GTPO implementation from "GTPO and GRPO-S: Token and Sequence-Level Reward Shaping with Policy Entropy" (Tan et al., arXiv 2508.04349)
- Implements all core equations (Eq. 3, 5, 6, 7) with three key features missing from the simplified version: **O+/O- separation**, **inverse entropy for confident mistakes**, and **position-dependent d_t/h_t**
- 26 new tests covering exact numerical verification, reward conservation (Prop 2.2), gradient detachment (Remark 2.5), and edge cases

## Paper vs Implementation — What Changed

| Feature | Simplified (`apply_entropy_weighting`) | Faithful (`compute_gtpo_shaped_rewards`) |
|---|---|---|
| O+/O- treatment | Unified | Separate (Eq. 3 vs Eq. 5) |
| Entropy for failures | H (same as success) | 1/H (inverse — confident mistakes penalized harder) |
| Shaping mechanism | Multiplicative: `A * w(H)` | Additive: `α₁·r + α₂·f(H)·dₜ` |
| Position-dependent | No | Yes — `dₜ`/`hₜ` decrease as shorter episodes drop out |
| Advantage normalization | Single group | Separate per O+/O- (Eq. 6) |
| Reward conservation | Not guaranteed | Provably conserved when α₁+α₂=1 (Prop 2.2) |

## New Functions

- `compute_gtpo_shaped_rewards()` — Eq. 3 + Eq. 5, returns flat 1D shaped rewards
- `normalize_gtpo_advantages()` — Eq. 6, separate O+/O- normalization  
- `gtpo_loss_faithful()` — Eq. 7, full GTPO objective

The simplified version is preserved unchanged for backward compatibility.

## Verified Properties

- **Reward conservation** (Prop 2.2): Σ r̃⁺ = dₜ at every position when α₁+α₂=1
- **Inverse entropy**: confident mistake (H=0.5) penalized ~5× harder than uncertain (H=4.0)
- **Gradient detachment**: ∂loss/∂entropy = 0 (numerically verified via `mx.grad`)
- **434 tests pass**, 0 regressions

## Test plan

- [x] 26 new tests in `test_gtpo_faithful.py` (all pass)
- [x] 46 existing GTPO tests unchanged (all pass)
- [x] Full unit suite: 434 passed, 1 skipped, 0 failed
- [ ] Reviewer: verify paper equations match implementation (docstrings cite exact equation numbers)
- [ ] Integration test with trainer (future PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/teilomillet/textpolicy/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
